### PR TITLE
[CMP-24] Pause and resume playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The plan is to create a cross-platform music player app that can
 
 - A mostly blank electron and web app
 - The electron app can import music from folders on your system and add them to a library and display the songs as a list
-- Plays clicked songs from start to finish (with no controls yet)
+- Plays clicked songs from start to finish
 
 ## Run the project
 

--- a/src-core/audio-player/audio-player.ts
+++ b/src-core/audio-player/audio-player.ts
@@ -28,6 +28,7 @@ export interface AudioPlayer {
   supports(mimeType: string): boolean;
   play(audio: Audio): void;
   pause(): void;
+  resume(): void;
   on<Event extends keyof AudioPlayerEvents>(event: Event, handler: AudioPlayerEvents[Event]): void;
   once<Event extends keyof AudioPlayerEvents>(
     event: Event,

--- a/src-core/audio-player/audio-player.ts
+++ b/src-core/audio-player/audio-player.ts
@@ -4,31 +4,34 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import type { Track } from '../library';
-
-export type PlayerEvents = {
-  started: (track: Track) => void;
-  buffering: (track: Track) => void;
-  playing: (track: Track) => void;
-  paused: (track: Track) => void;
-  stopped: (track: Track) => void;
+export type AudioPlayerEvents = {
+  started: () => void;
+  buffering: () => void;
+  playing: () => void;
+  paused: () => void;
+  stopped: () => void;
   error: (e: PlaybackError) => void;
 };
 
 export class PlaybackError extends Error {
-  constructor(
-    reason: string,
-    public readonly track?: Track,
-  ) {
-    super(`Playback Error${track ? `: Error while playing ${track.name}` : ''}: ${reason}`);
+  constructor(reason: string) {
+    super(`Playback Error: ${reason}`);
   }
 }
 
+export type Audio = {
+  mimeType: string;
+  stream: ReadableStream<Uint8Array>;
+};
+
 export interface AudioPlayer {
-  readonly currentlyPlaying: Track | null;
   supports(mimeType: string): boolean;
-  play(track: Track, stream: ReadableStream<Uint8Array>): void;
-  on<Event extends keyof PlayerEvents>(event: Event, handler: PlayerEvents[Event]): void;
-  once<Event extends keyof PlayerEvents>(event: Event, handler: PlayerEvents[Event]): void;
-  off<Event extends keyof PlayerEvents>(event: Event, handler: PlayerEvents[Event]): void;
+  play(audio: Audio): void;
+  pause(): void;
+  on<Event extends keyof AudioPlayerEvents>(event: Event, handler: AudioPlayerEvents[Event]): void;
+  once<Event extends keyof AudioPlayerEvents>(
+    event: Event,
+    handler: AudioPlayerEvents[Event],
+  ): void;
+  off<Event extends keyof AudioPlayerEvents>(event: Event, handler: AudioPlayerEvents[Event]): void;
 }

--- a/src-core/audio-player/index.ts
+++ b/src-core/audio-player/index.ts
@@ -4,4 +4,5 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-export type { AudioPlayer } from './audio-player';
+export type { AudioPlayer, Audio, AudioPlayerEvents } from './audio-player';
+export { PlaybackError } from './audio-player';

--- a/src-core/library/player.ts
+++ b/src-core/library/player.ts
@@ -61,6 +61,10 @@ export class Player {
     this.audioPlayer.pause();
   }
 
+  resume() {
+    this.audioPlayer.resume();
+  }
+
   on<E extends keyof PlayerEvents>(event: E, handler: PlayerEvents[E]) {
     this.events.on(event, handler);
   }

--- a/src-core/library/player.ts
+++ b/src-core/library/player.ts
@@ -36,9 +36,11 @@ export class Player {
       this.events.emit('play');
     });
     audioPlayer.on('paused', () => {
+      this.state = 'paused';
       this.events.emit('pause');
     });
     audioPlayer.on('stopped', () => {
+      this.state = 'paused';
       this.events.emit('pause');
     });
   }
@@ -53,6 +55,10 @@ export class Player {
     const stream = source.stream(track);
     this.currentlyPlaying = track;
     this.audioPlayer.play({ mimeType: track.mime, stream });
+  }
+
+  pause() {
+    this.audioPlayer.pause();
   }
 
   on<E extends keyof PlayerEvents>(event: E, handler: PlayerEvents[E]) {

--- a/src/audio-player/html-audio-player.ts
+++ b/src/audio-player/html-audio-player.ts
@@ -101,6 +101,11 @@ export default class HtmlAudioPlayer implements AudioPlayer {
     this.audio.pause();
   }
 
+  resume(): void {
+    this.events.emit('buffering');
+    void this.audio.play();
+  }
+
   private async playAsMediaSource(audio: Audio) {
     const unplayedChunks: Uint8Array[] = [];
 

--- a/src/audio-player/index.ts
+++ b/src/audio-player/index.ts
@@ -4,4 +4,4 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-export * from './html-audio-player';
+export { default as default } from './html-audio-player';

--- a/src/components/PlayerIndicator.vue
+++ b/src/components/PlayerIndicator.vue
@@ -25,6 +25,10 @@ const currentlyPlaying = library.player.currentlyPlaying;
 const playerState = library.player.state;
 
 function togglePlayState() {
-  library.player.pause();
+  if (library.player.state.value === 'playing') {
+    library.player.pause();
+  } else {
+    library.player.resume();
+  }
 }
 </script>

--- a/src/components/PlayerIndicator.vue
+++ b/src/components/PlayerIndicator.vue
@@ -1,0 +1,30 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
+<template>
+  <q-card v-if="currentlyPlaying" class="absolute-bottom q-mx-lg">
+    <q-card-section>
+      <div class="row">
+        <q-btn
+          :icon="playerState === 'playing' ? 'pause' : 'arrow_right'"
+          @click="togglePlayState"
+        />
+        <p>{{ currentlyPlaying.name }}</p>
+      </div>
+    </q-card-section>
+  </q-card>
+</template>
+
+<script setup lang="ts">
+import useLibrary from 'src/composables/library/use-library';
+
+const library = useLibrary();
+
+const currentlyPlaying = library.player.currentlyPlaying;
+const playerState = library.player.state;
+
+function togglePlayState() {
+  library.player.pause();
+}
+</script>

--- a/src/composables/library/library-factory.ts
+++ b/src/composables/library/library-factory.ts
@@ -11,7 +11,7 @@ import { ElectronDeviceStorage } from 'app/src-electron/storage/device/electron-
 import { useQuasar } from 'quasar';
 import { LibraryDatabase } from 'src/library/store/indexed-db/db';
 import { IndexedDbTrackStore } from 'src/library/store/indexed-db/track';
-import HtmlAudioPlayer from 'src/audio-player/html-audio-player';
+import HtmlAudioPlayer from 'src/audio-player';
 
 export default function createLibrary() {
   const $q = useQuasar();

--- a/src/composables/library/use-library.ts
+++ b/src/composables/library/use-library.ts
@@ -45,7 +45,7 @@ export default function useLibrary() {
     job.on('complete', onImportComplete);
   }
 
-  function onPlay() {
+  function onPlayerStateChange() {
     currentlyPlaying.value = library.value.player.currentlyPlaying;
     playerState.value = library.value.player.state;
   }
@@ -55,14 +55,16 @@ export default function useLibrary() {
       onImport(importJob.value);
     }
 
-    library.value.player.on('play', onPlay);
+    library.value.player.on('play', onPlayerStateChange);
+    library.value.player.on('pause', onPlayerStateChange);
   });
 
   onUnmounted(() => {
     importJob.value?.off('import', onImportProgress);
     importJob.value?.off('importError', onImportErrors);
     importJob.value?.off('complete', onImportComplete);
-    library.value.player.off('play', onPlay);
+    library.value.player.off('play', onPlayerStateChange);
+    library.value.player.off('pause', onPlayerStateChange);
   });
 
   function startImport<K extends string, I, M>(source: Source<K, I, M>, inputs: I) {
@@ -96,6 +98,7 @@ export default function useLibrary() {
     player: {
       play: library.value.player.play.bind(library.value.player),
       pause: library.value.player.pause.bind(library.value.player),
+      resume: library.value.player.resume.bind(library.value.player),
       state: playerState,
       currentlyPlaying,
     },

--- a/src/composables/library/use-library.ts
+++ b/src/composables/library/use-library.ts
@@ -44,8 +44,8 @@ export default function useLibrary() {
     job.on('complete', onImportComplete);
   }
 
-  function onCurrentlyPlayingChange(track: Track) {
-    currentlyPlaying.value = track;
+  function onPlay() {
+    currentlyPlaying.value = library.value.player.currentlyPlaying;
   }
 
   onMounted(() => {
@@ -53,14 +53,14 @@ export default function useLibrary() {
       onImport(importJob.value);
     }
 
-    library.value.player.on('start', onCurrentlyPlayingChange);
+    library.value.player.on('play', onPlay);
   });
 
   onUnmounted(() => {
     importJob.value?.off('import', onImportProgress);
     importJob.value?.off('importError', onImportErrors);
     importJob.value?.off('complete', onImportComplete);
-    library.value.player.off('start', onCurrentlyPlayingChange);
+    library.value.player.off('play', onPlay);
   });
 
   function startImport<K extends string, I, M>(source: Source<K, I, M>, inputs: I) {

--- a/src/composables/library/use-library.ts
+++ b/src/composables/library/use-library.ts
@@ -23,6 +23,7 @@ export default function useLibrary() {
   const importErrors = inject(importErrorsInjectionKey, ref([]));
 
   const currentlyPlaying = ref(library.value.player.currentlyPlaying);
+  const playerState = ref(library.value.player.state);
 
   const tracks = shallowRef<Track[]>([]);
 
@@ -46,6 +47,7 @@ export default function useLibrary() {
 
   function onPlay() {
     currentlyPlaying.value = library.value.player.currentlyPlaying;
+    playerState.value = library.value.player.state;
   }
 
   onMounted(() => {
@@ -93,6 +95,8 @@ export default function useLibrary() {
     },
     player: {
       play: library.value.player.play.bind(library.value.player),
+      pause: library.value.player.pause.bind(library.value.player),
+      state: playerState,
       currentlyPlaying,
     },
   };

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -9,9 +9,7 @@
     <main class="column no-wrap" style="padding-top: 0; flex: 1 1 auto; overflow: hidden">
       <router-view />
 
-      <q-card v-if="currentlyPlaying" class="absolute-bottom q-mx-lg">
-        <q-card-section> {{ currentlyPlaying.name }} </q-card-section>
-      </q-card>
+      <PlayerIndicator />
     </main>
   </div>
 </template>
@@ -20,12 +18,9 @@
 import NavHeader from 'src/components/NavHeader.vue';
 import type { NavLink } from 'src/components/nav-header-models';
 import { useI18n } from 'vue-i18n';
-import useLibrary from 'src/composables/library/use-library';
+import PlayerIndicator from 'src/components/PlayerIndicator.vue';
 
 const { t } = useI18n();
-const library = useLibrary();
-
-const currentlyPlaying = library.player.currentlyPlaying;
 
 const links: NavLink[] = [
   {

--- a/test/vitest/__tests__/source/device/player.spec.ts
+++ b/test/vitest/__tests__/source/device/player.spec.ts
@@ -65,12 +65,14 @@ describe('Player + device source', () => {
     expect(library.player.state).toEqual('playing');
   });
 
-  it('should pause track', async () => {
+  it('should pause and resume track', async () => {
     const { deviceSource, library, audioPlayer } = createDeviceLibraryFixture(nodeFs);
     const filePath = resolve(
       'test/fixtures/music/Kevin MacLeod - I Got a Stick Arr Bryan Teoh.mp3',
     );
+    const onPlay = vi.fn();
     const onPause = vi.fn();
+    library.player.on('play', onPlay);
     library.player.on('pause', onPause);
 
     const job = library.import(deviceSource, [filePath]);
@@ -103,5 +105,19 @@ describe('Player + device source', () => {
 
     expect(onPause).toHaveBeenCalled();
     expect(library.player.state).toEqual('paused');
+
+    onPlay.mockReset();
+
+    await new Promise<void>((resolve) => {
+      vi.spyOn(audioPlayer, 'resume').mockImplementationOnce(() => {
+        audioPlayer.emit('playing');
+        resolve();
+      });
+
+      library.player.resume();
+    });
+
+    expect(onPlay).toHaveBeenCalled();
+    expect(library.player.state).toEqual('playing');
   });
 });

--- a/test/vitest/mock/mock-player.ts
+++ b/test/vitest/mock/mock-player.ts
@@ -17,4 +17,7 @@ export class MockAudioPlayer extends EventEmitter implements AudioPlayer {
   pause(): void {
     throw new Error('Method not implemented.');
   }
+  resume(): void {
+    throw new Error('Method not implemented.');
+  }
 }

--- a/test/vitest/mock/mock-player.ts
+++ b/test/vitest/mock/mock-player.ts
@@ -2,25 +2,19 @@
  * https://creativecommons.org/publicdomain/zero/1.0/ */
 
 import type { Track } from 'app/src-core/library';
-import type { AudioPlayer } from 'app/src-core/audio-player';
-import type { PlayerEvents } from 'app/src-core/audio-player/audio-player';
+import type { Audio, AudioPlayer } from 'app/src-core/audio-player';
+import EventEmitter from 'events';
 
-export class MockAudioPlayer implements AudioPlayer {
-  currentlyPlaying: Track | null = null;
+export class MockAudioPlayer extends EventEmitter implements AudioPlayer {
+  track: Track | null = null;
 
-  on<Event extends keyof PlayerEvents>(_event: Event, _handler: PlayerEvents[Event]): void {
-    // do nothing
-  }
-  once<Event extends keyof PlayerEvents>(_event: Event, _handler: PlayerEvents[Event]): void {
-    throw new Error('Method not implemented.');
-  }
-  off<Event extends keyof PlayerEvents>(_event: Event, _handler: PlayerEvents[Event]): void {
-    throw new Error('Method not implemented.');
-  }
   supports(ext: string) {
     return ['audio/mpeg', 'audio/ogg', 'audio/aac', 'audio/flac'].includes(ext);
   }
-  play(_track: Track, _stream: ReadableStream<Uint8Array>): void {
+  play(_audio: Audio): void {
+    throw new Error('Method not implemented.');
+  }
+  pause(): void {
     throw new Error('Method not implemented.');
   }
 }


### PR DESCRIPTION
## Changes

* Restructured AudioPlayer interface:
  * This interface now only deals with playing audio media. It doesn't know or care about `Tracks` or libraries
  * It doesn't keep track of track state. Just emits events.
  * The Library `Player` class will do the work of keeping track of track state using events from `AudioPlayer`
* Added functionality to pause and resume a playing track

## PR Checklist

- [x] Core functionality has sufficient tests (non-UI code, code that isn't too platform specific)
- [x] Module exports are as neat as can be (default exports, named exports, index.ts)
- [x] No unnecessary comments/TODOs
- [x] No hardcoded UI strings. Use transaltion
- [x] README updated if anything significant has changed
