### PR TITLE
[CMP-26] Update track list after import completes

### DIFF
--- a/src/composables/library/use-library-provider.ts
+++ b/src/composables/library/use-library-provider.ts
@@ -7,22 +7,33 @@
 import type { InjectionKey, Ref, ShallowRef } from 'vue';
 import { provide, ref, shallowRef } from 'vue';
 import createLibrary from './library-factory';
-import type { Library, ImportJob, ImportProgress } from 'app/src-core/library';
+import type { Library, ImportJob, ImportProgress, Track } from 'app/src-core/library';
 import type { TrackImportError } from 'app/src-core/library/track-importer';
 
 export const libraryInjectionKey = Symbol() as InjectionKey<ShallowRef<Library>>;
 export const importJobInjectionKey = Symbol() as InjectionKey<ShallowRef<ImportJob | null>>;
 export const importProgressInjectionKey = Symbol() as InjectionKey<Ref<ImportProgress | null>>;
 export const importErrorsInjectionKey = Symbol() as InjectionKey<Ref<TrackImportError[]>>;
+export const tracksInjectionKey = Symbol() as InjectionKey<{
+  tracks: ShallowRef<Track[]>;
+  setTracks: (tracks: Track[]) => void;
+}>;
 
 export default function useLibraryProvider() {
   const library = shallowRef<Library>(createLibrary());
   const importJob = shallowRef<ImportJob | null>(null);
   const importProgress = ref<ImportProgress | null>(null);
   const importErrors = ref<TrackImportError[]>([]);
+  const tracks = shallowRef<Track[]>([]);
 
   provide(libraryInjectionKey, library);
   provide(importJobInjectionKey, importJob);
   provide(importProgressInjectionKey, importProgress);
   provide(importErrorsInjectionKey, importErrors);
+  provide(tracksInjectionKey, {
+    tracks,
+    setTracks(_tracks) {
+      tracks.value = _tracks;
+    },
+  });
 }

--- a/src/composables/library/use-library.ts
+++ b/src/composables/library/use-library.ts
@@ -12,6 +12,7 @@ import {
   importJobInjectionKey,
   importProgressInjectionKey,
   libraryInjectionKey,
+  tracksInjectionKey,
 } from './use-library-provider';
 import type { TrackImportError } from 'app/src-core/library/track-importer';
 import type { ImportJob, ImportProgress, Library, Track } from 'app/src-core/library';
@@ -33,9 +34,12 @@ export default function useLibrary() {
   const importJob = inject(importJobInjectionKey, ref(null));
   const importProgress = inject(importProgressInjectionKey, ref(null));
   const importErrors = inject(importErrorsInjectionKey, ref([]));
+  const { tracks, setTracks } = inject(tracksInjectionKey, {
+    tracks: shallowRef([]),
+    setTracks: () => {},
+  });
   const currentlyPlaying = ref(library.value.player.currentlyPlaying);
   const playerState = ref(library.value.player.state);
-  const tracks = shallowRef<Track[]>([]);
 
   function onImportProgress(tracks: Track[], progress: ImportProgress) {
     importProgress.value = progress;
@@ -47,6 +51,7 @@ export default function useLibrary() {
 
   function onImportComplete(progress: ImportProgress) {
     importProgress.value = progress;
+    void findTracks();
   }
 
   function onImport(job: ImportJob) {
@@ -100,7 +105,7 @@ export default function useLibrary() {
   }
 
   async function findTracks() {
-    tracks.value = await library.value.tracks.list({ limit: 1000000, offset: 0 });
+    setTracks(await library.value.tracks.list({ limit: 1000000, offset: 0 }));
   }
 
   return {


### PR DESCRIPTION
## Changes

* After import, refresh list of tracks
* Move track list out of `useLibrary()` and into `useLibraryProvider()` so that there's one global copy used by all callers of the composable function

## PR Checklist

- [x] Core functionality has sufficient tests (non-UI code, code that isn't too platform specific)
- [x] Module exports are as neat as can be (default exports, named exports, index.ts)
- [x] No unnecessary comments/TODOs
- [x] No hardcoded UI strings. Use transaltion
- [x] README updated if anything significant has changed
