### PR TITLE
[CMP-35] Display song metadata in currently playing viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The plan is to create a cross-platform music player app that can
 - A mostly blank electron and web app
 - The electron app can import music from folders on your system and add them to a library and display the songs as a list
 - Plays clicked songs from start to finish
+- Can play/pause songs
 
 ## Run the project
 

--- a/src-core/library/global-events.ts
+++ b/src-core/library/global-events.ts
@@ -1,0 +1,15 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { EventEmitter } from 'events';
+import type TypedEventEmitter from 'typed-emitter';
+import type { Track } from './track';
+
+export type GlobalEvents = {
+  [key: `trackMetadataUpdate:${string}`]: (track: Track) => void;
+};
+
+export default new EventEmitter() as TypedEventEmitter<GlobalEvents>;

--- a/src-core/library/index.ts
+++ b/src-core/library/index.ts
@@ -21,3 +21,4 @@ export type { Track, Identifier, Metadata } from './track';
 export { Player } from './player';
 export type { PlayerEvents } from './player';
 export * from './errors';
+export { default as globalEvents } from './global-events';

--- a/src-core/library/job/metadata-extraction-job.ts
+++ b/src-core/library/job/metadata-extraction-job.ts
@@ -88,7 +88,7 @@ export class MetadataExtractionJob {
 
       for (
         let tracks = tracksToUpdate.splice(0, 5);
-        tracks.length > 1;
+        tracks.length > 0;
         tracks = tracksToUpdate.splice(0, 5)
       ) {
         if (this.canceled) {

--- a/src-core/library/job/metadata-extraction-job.ts
+++ b/src-core/library/job/metadata-extraction-job.ts
@@ -11,6 +11,7 @@ import type { Source } from '../../source';
 import { getErrorMessage } from '../../error/util';
 import type { TrackStore } from '../store/track';
 import type { Track } from '../track';
+import globalEvents from '../global-events';
 import { Consumer, Producer } from 'app/src-core/util/producer-consumer';
 
 export class MetadataExtractionError extends Error {
@@ -154,6 +155,8 @@ export class MetadataExtractionJob {
       }
 
       await Promise.all(updates);
+
+      globalEvents.emit(`trackMetadataUpdate:${track.id}`, track);
     } catch (e) {
       this.events.emit('error', new MetadataExtractionError(getErrorMessage(e), track));
     }

--- a/src/components/PlayerIndicator.vue
+++ b/src/components/PlayerIndicator.vue
@@ -23,37 +23,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue';
-import { usePlayer, useTracks } from 'src/composables/library';
+import { usePlayer, useTrackInfo } from 'src/composables/library';
 
-const { currentlyPlaying, state, pause, resume } = usePlayer();
-const { getArtwork } = useTracks();
-
-const title = computed(
-  () => currentlyPlaying.value?.metadata?.title || currentlyPlaying.value?.file.name,
-);
-const artist = computed(() => currentlyPlaying.value?.metadata?.artist || 'Unknown Artist');
-const album = computed(() => currentlyPlaying.value?.metadata?.album || 'Unknown Album');
-const artworkUrl = ref<string | null>(null);
-
-watch(currentlyPlaying, async () => {
-  if (artworkUrl.value) {
-    URL.revokeObjectURL(artworkUrl.value);
-    artworkUrl.value = null;
-  }
-
-  if (!currentlyPlaying.value) {
-    return;
-  }
-
-  const artworkData = await getArtwork(currentlyPlaying.value);
-
-  if (!artworkData) {
-    return;
-  }
-
-  artworkUrl.value = URL.createObjectURL(new Blob([artworkData]));
-});
+const { pause, resume, currentlyPlaying, state } = usePlayer();
+const { album, artist, artworkUrl, title } = useTrackInfo(currentlyPlaying);
 
 function togglePlayState() {
   if (state.value === 'playing') {

--- a/src/components/PlayerIndicator.vue
+++ b/src/components/PlayerIndicator.vue
@@ -6,6 +6,8 @@
   <q-card v-if="currentlyPlaying" class="absolute-bottom q-mx-lg">
     <q-card-section>
       <div class="row">
+        <img v-if="artworkUrl" class="album-art col-auto" :src="artworkUrl" />
+        <img v-else class="album-art col-auto" />
         <div class="q-ml-lg col column">
           <p class="row q-ma-none">{{ artist }} - {{ title }}</p>
           <p class="row q-ma-none">{{ album }}</p>
@@ -21,16 +23,37 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
-import { usePlayer } from 'src/composables/library';
+import { computed, ref, watch } from 'vue';
+import { usePlayer, useTracks } from 'src/composables/library';
 
 const { currentlyPlaying, state, pause, resume } = usePlayer();
+const { getArtwork } = useTracks();
 
 const title = computed(
   () => currentlyPlaying.value?.metadata?.title || currentlyPlaying.value?.file.name,
 );
 const artist = computed(() => currentlyPlaying.value?.metadata?.artist || 'Unknown Artist');
 const album = computed(() => currentlyPlaying.value?.metadata?.album || 'Unknown Album');
+const artworkUrl = ref<string | null>(null);
+
+watch(currentlyPlaying, async () => {
+  if (artworkUrl.value) {
+    URL.revokeObjectURL(artworkUrl.value);
+    artworkUrl.value = null;
+  }
+
+  if (!currentlyPlaying.value) {
+    return;
+  }
+
+  const artworkData = await getArtwork(currentlyPlaying.value);
+
+  if (!artworkData) {
+    return;
+  }
+
+  artworkUrl.value = URL.createObjectURL(new Blob([artworkData]));
+});
 
 function togglePlayState() {
   if (state.value === 'playing') {
@@ -40,3 +63,12 @@ function togglePlayState() {
   }
 }
 </script>
+
+<style lang="css" scoped>
+.album-art {
+  background: #c4c4c4;
+  width: 52px;
+  height: 52px;
+  border-radius: 5px;
+}
+</style>

--- a/src/components/PlayerIndicator.vue
+++ b/src/components/PlayerIndicator.vue
@@ -6,29 +6,37 @@
   <q-card v-if="currentlyPlaying" class="absolute-bottom q-mx-lg">
     <q-card-section>
       <div class="row">
+        <div class="q-ml-lg col column">
+          <p class="row q-ma-none">{{ artist }} - {{ title }}</p>
+          <p class="row q-ma-none">{{ album }}</p>
+        </div>
         <q-btn
-          :icon="playerState === 'playing' ? 'pause' : 'arrow_right'"
+          class="col-auto"
+          :icon="state === 'playing' ? 'pause' : 'arrow_right'"
           @click="togglePlayState"
         />
-        <p>{{ currentlyPlaying.file.name }}</p>
       </div>
     </q-card-section>
   </q-card>
 </template>
 
 <script setup lang="ts">
-import useLibrary from 'src/composables/library/use-library';
+import { computed } from 'vue';
+import { usePlayer } from 'src/composables/library';
 
-const library = useLibrary();
+const { currentlyPlaying, state, pause, resume } = usePlayer();
 
-const currentlyPlaying = library.player.currentlyPlaying;
-const playerState = library.player.state;
+const title = computed(
+  () => currentlyPlaying.value?.metadata?.title || currentlyPlaying.value?.file.name,
+);
+const artist = computed(() => currentlyPlaying.value?.metadata?.artist || 'Unknown Artist');
+const album = computed(() => currentlyPlaying.value?.metadata?.album || 'Unknown Album');
 
 function togglePlayState() {
-  if (library.player.state.value === 'playing') {
-    library.player.pause();
+  if (state.value === 'playing') {
+    pause();
   } else {
-    library.player.resume();
+    resume();
   }
 }
 </script>

--- a/src/components/import/ImportMenu.vue
+++ b/src/components/import/ImportMenu.vue
@@ -15,19 +15,19 @@
 <script setup lang="ts">
 import { ref } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { useLibrary } from 'src/composables/library';
 import ImportSourcePicker from 'src/components/import/ImportSourcePicker.vue';
 import ImportProgress from 'src/components/import/ImportProgress.vue';
 import type { Source } from 'app/src-core/source';
+import { useImport } from 'src/composables/library';
 
 const { t } = useI18n();
 
-const library = useLibrary();
+const { import: start } = useImport();
 const sourcePickerDialog = ref(false);
 const importDialog = ref(false);
 
 function startImport<K extends string, I, M>(source: Source<K, I, M>, inputs: I) {
-  library.import.start(source, inputs);
+  start(source, inputs);
   sourcePickerDialog.value = false;
   importDialog.value = true;
 }

--- a/src/components/import/ImportProgress.vue
+++ b/src/components/import/ImportProgress.vue
@@ -34,14 +34,11 @@
 
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n';
-import { useLibrary } from 'src/composables/library';
+import { useImport } from 'src/composables/library';
 
 const { t } = useI18n();
-const library = useLibrary();
-
+const { importProgress, importErrors } = useImport();
 const model = defineModel<boolean>({ default: true });
-const importProgress = library.import.progress;
-const importErrors = library.import.errors;
 </script>
 
 <style lang="css" scoped>

--- a/src/components/import/ImportSourcePicker.vue
+++ b/src/components/import/ImportSourcePicker.vue
@@ -28,9 +28,9 @@
 import type { Source } from 'app/src-core/source';
 import type { DeviceSource } from 'app/src-core/source/device';
 import { DEVICE_SOURCE_NAME } from 'app/src-core/source/device';
-import { useLibrary } from 'src/composables/library';
+import { useImport } from 'src/composables/library';
 
-const { getSource } = useLibrary();
+const { getSource } = useImport();
 
 const model = defineModel<boolean>({ default: true });
 const emits = defineEmits<{

--- a/src/composables/library/index.ts
+++ b/src/composables/library/index.ts
@@ -8,3 +8,4 @@ export { default as useImport } from './use-import';
 export { default as useLibraryProvider } from './use-library-provider';
 export { default as usePlayer } from './use-player';
 export { default as useTracks } from './use-tracks';
+export { default as useTrackInfo } from './use-track-info';

--- a/src/composables/library/index.ts
+++ b/src/composables/library/index.ts
@@ -4,5 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-export { default as useLibrary } from './use-library';
+export { default as useImport } from './use-import';
 export { default as useLibraryProvider } from './use-library-provider';
+export { default as usePlayer } from './use-player';
+export { default as useTracks } from './use-tracks';

--- a/src/composables/library/use-import.ts
+++ b/src/composables/library/use-import.ts
@@ -59,7 +59,7 @@ export default function useLibrary() {
   }
 
   function onMetadataError(e: MetadataExtractionError) {
-    Notify.create({ type: 'error', message: e.message });
+    Notify.create({ type: 'negative', message: e.message });
   }
 
   onMounted(() => {

--- a/src/composables/library/use-library-provider.ts
+++ b/src/composables/library/use-library-provider.ts
@@ -5,7 +5,7 @@
  */
 
 import type { InjectionKey, Ref, ShallowRef } from 'vue';
-import { provide, ref, shallowRef } from 'vue';
+import { inject, provide, ref, shallowRef } from 'vue';
 import createLibrary from './library-factory';
 import type {
   Library,
@@ -27,6 +27,16 @@ export const tracksInjectionKey = Symbol() as InjectionKey<{
   tracks: ShallowRef<Track[]>;
   setTracks: (tracks: Track[]) => void;
 }>;
+
+export function injectLibrary(): ShallowRef<Library> {
+  const library = inject(libraryInjectionKey);
+
+  if (!library) {
+    throw new Error('Library should have been provided with provide()');
+  }
+
+  return library;
+}
 
 export default function useLibraryProvider() {
   const library = shallowRef<Library>(createLibrary());

--- a/src/composables/library/use-player.ts
+++ b/src/composables/library/use-player.ts
@@ -26,16 +26,22 @@ export default function () {
     });
   }
 
+  function onTrackMetadataUpdated() {
+    currentlyPlaying.value = library.value.player.currentlyPlaying;
+  }
+
   onMounted(() => {
     library.value.player.on('play', onPlayerStateChange);
     library.value.player.on('pause', onPlayerStateChange);
     library.value.player.on('error', onPlayerError);
+    library.value.player.on('metadataUpdate', onTrackMetadataUpdated);
   });
 
   onUnmounted(() => {
     library.value.player.off('play', onPlayerStateChange);
     library.value.player.off('pause', onPlayerStateChange);
     library.value.player.off('error', onPlayerError);
+    library.value.player.off('metadataUpdate', onTrackMetadataUpdated);
   });
 
   return {

--- a/src/composables/library/use-player.ts
+++ b/src/composables/library/use-player.ts
@@ -1,0 +1,48 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { onMounted, onUnmounted, ref } from 'vue';
+import { Notify } from 'quasar';
+import { injectLibrary } from './use-library-provider';
+import type { PlaybackError } from 'app/src-core/audio-player';
+
+export default function () {
+  const library = injectLibrary();
+  const currentlyPlaying = ref(library.value.player.currentlyPlaying);
+  const playerState = ref(library.value.player.state);
+
+  function onPlayerStateChange() {
+    currentlyPlaying.value = library.value.player.currentlyPlaying;
+    playerState.value = library.value.player.state;
+  }
+
+  function onPlayerError(e: PlaybackError) {
+    Notify.create({
+      type: 'negative',
+      message: e.message,
+    });
+  }
+
+  onMounted(() => {
+    library.value.player.on('play', onPlayerStateChange);
+    library.value.player.on('pause', onPlayerStateChange);
+    library.value.player.on('error', onPlayerError);
+  });
+
+  onUnmounted(() => {
+    library.value.player.off('play', onPlayerStateChange);
+    library.value.player.off('pause', onPlayerStateChange);
+    library.value.player.off('error', onPlayerError);
+  });
+
+  return {
+    play: library.value.player.play.bind(library.value.player),
+    pause: library.value.player.pause.bind(library.value.player),
+    resume: library.value.player.resume.bind(library.value.player),
+    state: playerState,
+    currentlyPlaying,
+  };
+}

--- a/src/composables/library/use-track-info.ts
+++ b/src/composables/library/use-track-info.ts
@@ -1,0 +1,61 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { computed, onUnmounted, ref, watch, type Ref } from 'vue';
+import { Notify } from 'quasar';
+import useTracks from './use-tracks';
+import type { Track } from 'app/src-core/library';
+import { getErrorMessage } from 'app/src-core/error/util';
+
+export default function useTrackInfo(track: Ref<Track | null | undefined>) {
+  const { getArtwork } = useTracks();
+
+  const title = computed(() => track.value?.metadata?.title || track.value?.file.name);
+  const artist = computed(() => track.value?.metadata?.artist || 'Unknown Artist');
+  const album = computed(() => track.value?.metadata?.album || 'Unknown Album');
+  const artworkUrl = ref<string | null>(null);
+
+  async function updateArtworkUrl() {
+    try {
+      if (!track.value) {
+        return;
+      }
+
+      const artworkData = await getArtwork(track.value);
+
+      if (!artworkData) {
+        return;
+      }
+
+      artworkUrl.value = URL.createObjectURL(new Blob([artworkData]));
+    } catch (e) {
+      Notify.create({ type: 'negative', message: getErrorMessage(e) });
+    }
+  }
+
+  function revokeArtworkUrl() {
+    if (artworkUrl.value) {
+      URL.revokeObjectURL(artworkUrl.value);
+      artworkUrl.value = null;
+    }
+  }
+
+  watch(track, () => {
+    revokeArtworkUrl();
+    void updateArtworkUrl();
+  });
+
+  onUnmounted(() => {
+    revokeArtworkUrl();
+  });
+
+  return {
+    title,
+    artist,
+    album,
+    artworkUrl,
+  };
+}

--- a/src/composables/library/use-tracks.ts
+++ b/src/composables/library/use-tracks.ts
@@ -1,0 +1,26 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { inject, shallowRef } from 'vue';
+import { injectLibrary, tracksInjectionKey } from './use-library-provider';
+
+export default function () {
+  const library = injectLibrary();
+
+  const { tracks, setTracks } = inject(tracksInjectionKey, {
+    tracks: shallowRef([]),
+    setTracks: () => {},
+  });
+
+  async function findTracks() {
+    setTracks(await library.value.tracks.list({ limit: 1000000, offset: 0 }));
+  }
+
+  return {
+    list: tracks,
+    find: findTracks,
+  };
+}

--- a/src/composables/library/use-tracks.ts
+++ b/src/composables/library/use-tracks.ts
@@ -22,5 +22,6 @@ export default function () {
   return {
     list: tracks,
     find: findTracks,
+    getArtwork: library.value.tracks.getArtwork.bind(library.value.tracks),
   };
 }

--- a/src/pages/SongsPage.vue
+++ b/src/pages/SongsPage.vue
@@ -4,7 +4,7 @@
 
 <template>
   <div class="q-pl-md" style="flex: 1 1 auto; overflow: auto">
-    <q-virtual-scroll :items="tracks" separator v-slot="{ item }">
+    <q-virtual-scroll :items="list" separator v-slot="{ item }">
       <q-item :key="item.id" dense class="no-border">
         <div class="row items-center q-mt-md cursor-pointer col-grow" @click="play(item)">
           <img class="album-art" />
@@ -18,17 +18,16 @@
 <script setup lang="ts">
 import { onMounted } from 'vue';
 import type { Track } from 'app/src-core/library';
-import { useLibrary } from 'src/composables/library';
+import { usePlayer, useTracks } from 'src/composables/library';
 
-const library = useLibrary();
+const { find, list } = useTracks();
+const { play: playTrack } = usePlayer();
 
-onMounted(() => library.tracks.find());
+onMounted(() => find());
 
 function play(track: Track) {
-  library.player.play(track);
+  playTrack(track);
 }
-
-const tracks = library.tracks.list;
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Changes

* Added a global event emitter for any events that might need to be listened to from multiple places
* Emitting a global event whenever a track's metadata has been updated so that any component currently using that track can fetch the new data
* Fetching and displaying track metadata in the preview player on the bottom of the screen
* If the currently playing track's metadata is updated while playing, it will be refreshed

## PR Checklist

- [x] Core functionality has sufficient tests (non-UI code, code that isn't too platform specific)
- [x] Module exports are as neat as can be (default exports, named exports, index.ts)
- [x] No unnecessary comments/TODOs
- [x] No hardcoded UI strings. Use transaltion
- [x] README updated if anything significant has changed
