### PR TITLE
[CMP-36] Metadata in song list

### DIFF
--- a/src-core/library/global-events.ts
+++ b/src-core/library/global-events.ts
@@ -12,4 +12,8 @@ export type GlobalEvents = {
   [key: `trackMetadataUpdate:${string}`]: (track: Track) => void;
 };
 
-export default new EventEmitter() as TypedEventEmitter<GlobalEvents>;
+const events = new EventEmitter() as TypedEventEmitter<GlobalEvents>;
+
+events.setMaxListeners(200);
+
+export default events;

--- a/src-core/library/job/metadata-extraction-job.ts
+++ b/src-core/library/job/metadata-extraction-job.ts
@@ -27,6 +27,7 @@ export class MetadataExtractionError extends Error {
 
 export type MetadataJobEvents = {
   complete: () => void;
+  update: (track: Track) => void;
   error: (e: MetadataExtractionError) => void;
 };
 
@@ -157,6 +158,7 @@ export class MetadataExtractionJob {
       await Promise.all(updates);
 
       globalEvents.emit(`trackMetadataUpdate:${track.id}`, track);
+      this.events.emit('update', track);
     } catch (e) {
       this.events.emit('error', new MetadataExtractionError(getErrorMessage(e), track));
     }

--- a/src/components/track/TrackListItem.vue
+++ b/src/components/track/TrackListItem.vue
@@ -1,0 +1,42 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+- License, v. 2.0. If a copy of the MPL was not distributed with this
+- file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
+<template>
+  <div class="row items-center q-mt-md cursor-pointer col-grow">
+    <img v-if="artworkUrl" class="album-art col-auto" :src="artworkUrl" />
+    <img v-else class="album-art col-auto" />
+    <p class="q-ma-none q-ml-sm text-center">{{ artist }} - {{ title }}</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref } from 'vue';
+import { globalEvents, type Track } from 'app/src-core/library';
+import { useTrackInfo } from 'src/composables/library';
+
+const props = defineProps<{ track: Track }>();
+const track = ref(props.track);
+const { artist, artworkUrl, title } = useTrackInfo(track);
+
+function refreshTrack(_track: Track) {
+  track.value = _track;
+}
+
+onMounted(() => {
+  globalEvents.on(`trackMetadataUpdate:${track.value.id}`, refreshTrack);
+});
+
+onUnmounted(() => {
+  globalEvents.off(`trackMetadataUpdate:${track.value.id}`, refreshTrack);
+});
+</script>
+
+<style scoped>
+.album-art {
+  background: #c4c4c4;
+  width: 52px;
+  height: 52px;
+  border-radius: 5px;
+}
+</style>

--- a/src/composables/library/use-track-info.ts
+++ b/src/composables/library/use-track-info.ts
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { computed, onUnmounted, ref, watch, type Ref } from 'vue';
+import { computed, onMounted, onUnmounted, ref, watch, type Ref } from 'vue';
 import { Notify } from 'quasar';
 import useTracks from './use-tracks';
 import type { Track } from 'app/src-core/library';
@@ -16,7 +16,7 @@ export default function useTrackInfo(track: Ref<Track | null | undefined>) {
   const title = computed(() => track.value?.metadata?.title || track.value?.file.name);
   const artist = computed(() => track.value?.metadata?.artist || 'Unknown Artist');
   const album = computed(() => track.value?.metadata?.album || 'Unknown Album');
-  const artworkUrl = ref<string | null>(null);
+  const artworkUrl = ref<string | undefined>(undefined);
 
   async function updateArtworkUrl() {
     try {
@@ -39,12 +39,16 @@ export default function useTrackInfo(track: Ref<Track | null | undefined>) {
   function revokeArtworkUrl() {
     if (artworkUrl.value) {
       URL.revokeObjectURL(artworkUrl.value);
-      artworkUrl.value = null;
+      artworkUrl.value = undefined;
     }
   }
 
   watch(track, () => {
     revokeArtworkUrl();
+    void updateArtworkUrl();
+  });
+
+  onMounted(() => {
     void updateArtworkUrl();
   });
 

--- a/src/pages/SongsPage.vue
+++ b/src/pages/SongsPage.vue
@@ -3,8 +3,13 @@
 - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
 
 <template>
-  <div class="q-pl-md" style="flex: 1 1 auto; overflow: auto">
-    <q-virtual-scroll :items="list" separator v-slot="{ item }">
+  <div class="q-pl-md" style="flex: 1 1 auto; overflow: auto" ref="scroll-target">
+    <q-virtual-scroll
+      :items="list"
+      separator
+      v-slot="{ item }"
+      :scroll-target="scrollTarget || undefined"
+    >
       <q-item :key="item.id" dense class="no-border">
         <div class="row items-center q-mt-md cursor-pointer col-grow" @click="play(item)">
           <img class="album-art" />
@@ -16,10 +21,11 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted } from 'vue';
+import { onMounted, useTemplateRef } from 'vue';
 import type { Track } from 'app/src-core/library';
 import { usePlayer, useTracks } from 'src/composables/library';
 
+const scrollTarget = useTemplateRef('scroll-target');
 const { find, list } = useTracks();
 const { play: playTrack } = usePlayer();
 

--- a/src/pages/SongsPage.vue
+++ b/src/pages/SongsPage.vue
@@ -11,10 +11,7 @@
       :scroll-target="scrollTarget || undefined"
     >
       <q-item :key="item.id" dense class="no-border">
-        <div class="row items-center q-mt-md cursor-pointer col-grow" @click="play(item)">
-          <img class="album-art" />
-          <p class="q-ma-none q-ml-sm text-center">{{ item.file.name }}</p>
-        </div>
+        <TrackListItem :track="item" @click="play(item)" />
       </q-item>
     </q-virtual-scroll>
   </div>
@@ -22,8 +19,9 @@
 
 <script setup lang="ts">
 import { onMounted, useTemplateRef } from 'vue';
-import type { Track } from 'app/src-core/library';
+import TrackListItem from 'src/components/track/TrackListItem.vue';
 import { usePlayer, useTracks } from 'src/composables/library';
+import type { Track } from 'app/src-core/library';
 
 const scrollTarget = useTemplateRef('scroll-target');
 const { find, list } = useTracks();
@@ -35,12 +33,3 @@ function play(track: Track) {
   playTrack(track);
 }
 </script>
-
-<style scoped>
-.album-art {
-  background: #c4c4c4;
-  width: 52px;
-  height: 52px;
-  border-radius: 5px;
-}
-</style>

--- a/test/vitest/__tests__/source/device/metadata.spec.ts
+++ b/test/vitest/__tests__/source/device/metadata.spec.ts
@@ -20,12 +20,14 @@ describe('Music Metadata', () => {
     await new Promise<ImportProgress>((resolve) => importJob.on('complete', resolve));
     let tracks = await library.tracks.list({ limit: 10000, offset: 0 });
 
-    const onTrackMetadataUpdate = vi.fn((_track: Track) => {});
+    const onIndividualTrackUpdate = vi.fn((_track: Track) => {});
+    const onTrackUpdate = vi.fn((_track: Track) => {});
     tracks.forEach((track) =>
-      globalEvents.on(`trackMetadataUpdate:${track.id}`, onTrackMetadataUpdate),
+      globalEvents.on(`trackMetadataUpdate:${track.id}`, onIndividualTrackUpdate),
     );
 
     const updateJob = library.updateAllMetadata();
+    updateJob.on('update', onTrackUpdate);
     await new Promise<void>((resolve) => updateJob.on('complete', resolve));
 
     tracks = await library.tracks.list({ limit: 10000, offset: 0 });
@@ -70,7 +72,8 @@ describe('Music Metadata', () => {
       ),
     );
 
-    expect(sortBy(onTrackMetadataUpdate.mock.calls.flat(), 'id')).toEqual(sortBy(tracks, 'id'));
+    expect(sortBy(onIndividualTrackUpdate.mock.calls.flat(), 'id')).toEqual(sortBy(tracks, 'id'));
+    expect(sortBy(onTrackUpdate.mock.calls.flat(), 'id')).toEqual(sortBy(tracks, 'id'));
 
     const artwork = await Promise.all(tracks.map((t) => trackStore.getArtwork(t)));
 


### PR DESCRIPTION
## Changes

* Display song metadata in the song list
* Fix an issue with the virtual scroll component where it didn't know what the scroll container was. That's why it was rendering all items instead of the visible few. Do this so that not all album art is fetched into memory
* For all visible song items, listen for track metadata updates so that it's instantly visible
* Every 5 seconds during track metadata updates, refresh the track list

## PR Checklist

- [x] Core functionality has sufficient tests (non-UI code, code that isn't too platform specific)
- [x] Module exports are as neat as can be (default exports, named exports, index.ts)
- [x] No unnecessary comments/TODOs
- [x] No hardcoded UI strings. Use transaltion
- [x] README updated if anything significant has changed
